### PR TITLE
Fix objcopy command to generate raw binary image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJCOPY = $(ARCH)-objcopy
 all: clean hello.img
 
 hello.img: hello.elf
-	$(OBJCOPY) hello.elf -I binary hello.img
+	$(OBJCOPY) -O binary hello.elf hello.img
 
 hello.elf: hello.o link.ld Makefile
 	$(LD) -T link.ld --no-warn-rwx-segments -o hello.elf hello.o


### PR DESCRIPTION
I'm not sure if intended but I noticed the objcopy command in the Makefile is a no-op and doesn't really create a raw binary image but just copies the elf file again but with an .img extension.

If this is intended, please disregard.

Of course, on QEMU this is not an issue as it can boot ELF images directly but real and virtualised hardware will crash trying to boot the image with a boot loader not expecting ELF images. I got an illegal instruction error trying to boot it with u-boot but could get it to boot and print hello with a proper binary image like the one from the updated Makefile on this PR.